### PR TITLE
Support python 3.12: remove `pkg_resources` dependency

### DIFF
--- a/multiqc_ngi/__init__.py
+++ b/multiqc_ngi/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-from pkg_resources import get_distribution
+from importlib.metadata import version
 from multiqc.utils import config
 
-__version__ = get_distribution("multiqc_ngi").version
+__version__ = version("multiqc_ngi")
 config.multiqc_ngi_version = __version__

--- a/multiqc_ngi/multiqc_ngi.py
+++ b/multiqc_ngi/multiqc_ngi.py
@@ -14,8 +14,9 @@ import socket
 import subprocess
 import yaml
 
-from pkg_resources import get_distribution
-__version__ = get_distribution("multiqc_ngi").version
+from importlib.metadata import version
+
+__version__ = version("multiqc_ngi")
 
 from multiqc.utils import report, util_functions, config
 


### PR DESCRIPTION
`pkg_resources` was removed in 3.12, so replacing its functionality to support the latest Python version.