### PR TITLE
Fixes for MultiQC v1.22

### DIFF
--- a/multiqc_ngi/__init__.py
+++ b/multiqc_ngi/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from importlib.metadata import version
-from multiqc.utils import config
+from multiqc import config
 
 __version__ = version("multiqc_ngi")
 config.multiqc_ngi_version = __version__

--- a/multiqc_ngi/multiqc_ngi.py
+++ b/multiqc_ngi/multiqc_ngi.py
@@ -18,7 +18,8 @@ from importlib.metadata import version
 
 __version__ = version("multiqc_ngi")
 
-from multiqc.utils import report, util_functions, config
+from multiqc import report, config
+from multiqc.utils import util_functions
 
 log = logging.getLogger('multiqc')
 

--- a/multiqc_ngi/multiqc_ngi.py
+++ b/multiqc_ngi/multiqc_ngi.py
@@ -322,7 +322,7 @@ class ngi_metadata():
             log.info('Found {} samples in StatusDB'.format(len(meta)))
 
             # Write to file
-            util_functions.write_data_file(meta, 'ngi_meta')
+            report.write_data_file(meta, 'ngi_meta')
 
             # Add to General Stats table
             gsdata = dict()

--- a/multiqc_ngi/multiqc_ngi.py
+++ b/multiqc_ngi/multiqc_ngi.py
@@ -296,7 +296,7 @@ class ngi_metadata():
     def fastqscreen_genome(self):
         """Add the Refrence genome from statusdb to fastq_screen html"""
         if report.ngi.get('reference_genome') is not None:
-            for m in report.modules_output:
+            for m in report.modules:
                 if m.anchor  == 'fastq_screen':
                     genome=report.ngi['reference_genome']
                     nice_names = {

--- a/multiqc_ngi/multiqc_ngi.py
+++ b/multiqc_ngi/multiqc_ngi.py
@@ -234,7 +234,7 @@ class ngi_metadata():
 
         config.title = '{}: {}'.format(pid, p_summary['project_name'])
         config.project_name = p_summary['project_name']
-        if config.analysis_dir and ('qc_ngi' in config.analysis_dir[0] or 'qc_ngi' in os.listdir()):
+        if config.analysis_dir and ('qc_ngi' in str(config.analysis_dir[0]) or 'qc_ngi' in os.listdir()):
             infix = 'qc'
         else:
             infix = 'pipeline'

--- a/multiqc_ngi/templates/ngi/header.html
+++ b/multiqc_ngi/templates/ngi/header.html
@@ -118,7 +118,7 @@ $(function(){
   &nbsp; <small><em>(6:06)</em></small>
 </div>
 
-{% if report.num_hc_plots > 0 and report.general_stats_html['rows'] | length > config.num_datasets_plot_limit %}
+{% if report.plot_data | length > 0 and report.general_stats_html['rows'] | length > config.num_datasets_plot_limit %}
 <div id="mqc-warning-many-samples" class="alert alert-warning alert-dismissible hidden-print">
   <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
   <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'simplejson',
         'pyyaml',
         'requests',
-        'multiqc'
+        'multiqc>=1.22.dev0'
     ],
     entry_points = {
         'multiqc.templates.v1': [


### PR DESCRIPTION
MultiQC v.1.22 is significantly refactored, so anding a few fixes to accommodate to some breaking changes.

* `report` and `config` modules were moved to the top level. 
* `config.analysis_dir` is a `Path` object
* `modules_output` was renamed to `modules`
* `write_data_file` was moved to the `report` module
* `report.num_hc_plots` was dropped following the removal of the HighCharts library
