### PR TITLE
Minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ docs/_build/
 
 # PyBuilder
 target/
+
+.idea

--- a/multiqc_ngi/multiqc_ngi.py
+++ b/multiqc_ngi/multiqc_ngi.py
@@ -83,11 +83,9 @@ class ngi_metadata():
                 return None
 
             # Run WGS Piper specific cleanup
-            for f in report.prep_ordered_search_files_list('piper_ngi')[1]:
-                if 'piper_ngi' in f[1].split(os.sep):
-                    log.info("Looks like WGS data - cleaning up report")
-                    self.ngi_wgs_cleanup()
-                    break
+            if 'piper_ngi' in report.files:
+                log.info("Looks like WGS data - cleaning up report")
+                self.ngi_wgs_cleanup()
 
             # Are we using the dummy test data?
             self.couch = None
@@ -539,20 +537,20 @@ class ngi_metadata():
 
     def connect_statusdb(self):
         """ Connect to statusdb """
+        conf_file = os.path.join(os.environ.get('HOME'), '.ngi_config', 'statusdb.yaml')
         try:
-            conf_file = os.path.join(os.environ.get('HOME'), '.ngi_config', 'statusdb.yaml')
             with open(conf_file, "r") as f:
                 sdb_config = yaml.safe_load(f)
                 log.debug("Got MultiQC_NGI statusdb config from the home directory.")
         except IOError:
-            log.debug("Could not open the MultiQC_NGI statusdb config file {conf_file}")
+            log.debug(f"Could not open the MultiQC_NGI statusdb config file {conf_file}")
             try:
                 with open(os.environ['STATUS_DB_CONFIG'], "r") as f:
                     sdb_config = yaml.safe_load(f)
                     log.debug(f"Got MultiQC_NGI statusdb config from $STATUS_DB_CONFIG: {os.environ['STATUS_DB_CONFIG']}")
             except (KeyError, IOError):
                 log.debug("Could not get the MultiQC_NGI statusdb config file from env STATUS_DB_CONFIG")
-                log.warn("Could not find a statusdb config file")
+                log.warning("Could not find a statusdb config file")
                 return None
         try:
             couch_user = sdb_config['statusdb']['username']
@@ -568,7 +566,7 @@ class ngi_metadata():
         try:
             requests.get(server_url, timeout=3)
         except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-            log.warn("Cannot contact statusdb - skipping NGI metadata stuff")
+            log.warning("Cannot contact statusdb - skipping NGI metadata stuff")
             return None
 
         return Server(server_url)

--- a/multiqc_ngi/templates/genstat/header.html
+++ b/multiqc_ngi/templates/genstat/header.html
@@ -10,6 +10,14 @@ was generated and the button that launches the welcome tour.
 
 <h1 id="page_title">{{ config.title }} : MultiQC Report</h1>
 
-<p>Report generated on {{ config.creation_date }} based on data in
-    <code id="mqc_analysis_path">{{ config.analysis_dir |join('</code>
-    and <code id="mqc_analysis_path">') }}</code></p>
+<p>Report generated on {{ config.creation_date }} based on data in:
+{% if report.analysis_files | length == 1 %}
+  <code class="mqc_analysis_path">{{ report.analysis_files[0] }}</code></p>
+{% else %}
+  </p>
+  <ul>
+    {% for d in report.analysis_files %}
+    <li><code class="mqc_analysis_path">{{ d }}</code></li>
+    {%  endfor %}
+  </ul>
+{% endif %}

--- a/multiqc_ngi/templates/genstat/header.html
+++ b/multiqc_ngi/templates/genstat/header.html
@@ -20,3 +20,4 @@ was generated and the button that launches the welcome tour.
     {%  endfor %}
   </ul>
 {% endif %}
+</p>

--- a/multiqc_ngi/templates/genstat/header.html
+++ b/multiqc_ngi/templates/genstat/header.html
@@ -12,9 +12,8 @@ was generated and the button that launches the welcome tour.
 
 <p>Report generated on {{ config.creation_date }} based on data in:
 {% if report.analysis_files | length == 1 %}
-  <code class="mqc_analysis_path">{{ report.analysis_files[0] }}</code></p>
+  <code class="mqc_analysis_path">{{ report.analysis_files[0] }}</code>
 {% else %}
-  </p>
   <ul>
     {% for d in report.analysis_files %}
     <li><code class="mqc_analysis_path">{{ d }}</code></li>

--- a/multiqc_ngi/templates/ngi/header.html
+++ b/multiqc_ngi/templates/ngi/header.html
@@ -65,10 +65,10 @@ was generated and the button that launches the welcome tour.
 
 <div id="analysis_dirs_wrapper">
   <p>Report generated on {{ config.creation_date }} based on data in:
-  {% if config.analysis_dir | length == 1 %}<code class="mqc_analysis_path">{{ config.analysis_dir[0] }}</code>
+  {% if report.analysis_files | length == 1 %}<code class="mqc_analysis_path">{{ report.analysis_files[0] }}</code>
   {% else %}
   <ul>
-    {% for d in config.analysis_dir %}
+    {% for d in report.analysis_files %}
     <li><code class="mqc_analysis_path">{{ d }}</code></li>
     {%  endfor %}
   </ul>


### PR DESCRIPTION
* `report.searchfiles` was removed in MultiQC v1.22, and you correctly worked around it; however, `report.files` can be checked here to simplify this block.
* moved `conf_file = ` before the `try` block, otherwise the type checker would complain about the use of an uninitiazlied variable below. We enabled [mypy](https://mypy.readthedocs.io/) across the MultiQC project, so it would be good to type check the NGI plugin is well.
* `log.warn` is deprecated, replaced with `log.warning`
* `config.analysis_dir` can be reset to the current working directory (e.g. the case of an interactive session), better show `report.analysis_files` in the report.