### PR TITLE
Enable `preserve_module_raw_data` in config to keep `saved_raw_data`

### DIFF
--- a/multiqc_ngi_config.yaml
+++ b/multiqc_ngi_config.yaml
@@ -24,3 +24,4 @@ save_remote: True
 remote_sshkey: '~/.ssh/id_rsa'  # Optional
 remote_port: '5912'             # Optional
 remote_destination: 'genomics.www@tools.scilifelab.se:/var/local/mqc_reports/'
+preserve_module_raw_data: True


### PR DESCRIPTION
Enable `preserve_module_raw_data: true` in config to keep `saved_raw_data` Needed to work with MultiQC [v1.26](https://github.com/MultiQC/MultiQC/pull/3026), context: https://github.com/MultiQC/MultiQC/pull/3010